### PR TITLE
Add ngOnDestroy & bump CSS Element Queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 /out-tsc
 
 # dependencies
-/node_modules
+node_modules
 
 # profiling files
 chrome-profiler-events.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-resize",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-resize",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "scripts": {
     "ng": "ng",
     "build": "ng build --project=angular-resize-event",

--- a/projects/angular-resize-event/package-lock.json
+++ b/projects/angular-resize-event/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-resize-event",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/projects/angular-resize-event/package-lock.json
+++ b/projects/angular-resize-event/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "angular-resize-event",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "css-element-queries": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/css-element-queries/-/css-element-queries-1.2.0.tgz",
+      "integrity": "sha512-4gaxpioSFueMcp9yj1TJFCLjfooGv38y6ZdwFUS3GuS+9NIVijdeiExXKwSIHoQDADfpgnaYSTzmJs+bV+Hehg=="
+    }
+  }
+}

--- a/projects/angular-resize-event/package.json
+++ b/projects/angular-resize-event/package.json
@@ -19,7 +19,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "css-element-queries": "1.1.1"
+    "css-element-queries": "1.2.0"
   },
   "peerDependencies": {
     "@angular/core": "^7.1.0",

--- a/projects/angular-resize-event/package.json
+++ b/projects/angular-resize-event/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-resize-event",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/vdolek/angular-resize-event"

--- a/projects/angular-resize-event/src/lib/resized.directive.ts
+++ b/projects/angular-resize-event/src/lib/resized.directive.ts
@@ -1,11 +1,11 @@
-import { Directive, ElementRef, EventEmitter, OnInit, Output } from '@angular/core';
+import { Directive, ElementRef, EventEmitter, OnInit, Output, OnDestroy } from '@angular/core';
 import { ResizeSensor } from 'css-element-queries';
 import { ResizedEvent } from './resized-event';
 
 @Directive({
   selector: '[resized]'
 })
-export class ResizedDirective implements OnInit {
+export class ResizedDirective implements OnInit, OnDestroy {
 
   @Output()
   readonly resized = new EventEmitter<ResizedEvent>();
@@ -13,13 +13,17 @@ export class ResizedDirective implements OnInit {
   private oldWidth: number;
   private oldHeight: number;
 
+  private resizeSensor: ResizeSensor;
+
   constructor(private readonly element: ElementRef) {
   }
 
   ngOnInit() {
-    // tslint:disable-next-line:no-unused-expression
-    new ResizeSensor(this.element.nativeElement, _ => this.onResized());
-    this.onResized();
+    this.resizeSensor = new ResizeSensor(this.element.nativeElement, () => this.onResized());
+  }
+
+  ngOnDestroy() {
+    this.resizeSensor.detach();
   }
 
   private onResized() {


### PR DESCRIPTION
- bump [CSS Element Queries](https://github.com/marcj/css-element-queries/releases/tag/1.2.0)
- `resizeSensor.detach()`
- remove `onResized()` inside init (v. 1.2 "Trigger initially the resize sensor callback")