### PR TITLE
Check if resizeSensor exists before detach

### DIFF
--- a/projects/angular-resize-event/src/lib/resized.directive.ts
+++ b/projects/angular-resize-event/src/lib/resized.directive.ts
@@ -23,7 +23,9 @@ export class ResizedDirective implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.resizeSensor.detach();
+    if (this.resizeSensor) {
+      this.resizeSensor.detach();
+    }
   }
 
   private onResized() {


### PR DESCRIPTION
Fix for TypeError: Cannot read property 'detach' of undefined at ResizedDirective.ngOnDestroy